### PR TITLE
横幅の広いパソコンでレイアウトが崩れているのを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@ input[type=radio], input[type=checkbox] {
 
 <div id="main">
 	<div id="title">PanCake web</div>
-	<ns-pancake id="pancake"></ns-pancake>
+	<ns-pancake id="pancake"></ns-pancake><br>
 	<input type="text" id="url" value="./test/openspc2-12.txt"><button id="btnget">GET</button><br>
 	<textarea id="ta"></textarea><br>
 	<div id="buttons">
@@ -126,7 +126,7 @@ btndemo.onclick = demo;
 </script>
 
 <div>
-こどもパソコン「<a href=https://ichigojam.net/>IchigoJam</a>」の拡張ボード「<a href=http://pancake.shizentai.jp/>PanCake</a>」をエミュレートする拡張タグ「<a href="https://github.com/ichigojam/ns-pancake/">ns-pancake</a>」タグ使用
+こどもパソコン「<a href=https://ichigojam.net/>IchigoJam</a>」の拡張ボード「<a href=http://pancake.shizentai.jp/>PanCake</a>」をエミュレートする拡張タグ「<a href="https://github.com/ichigojam/ns-pancake/">ns-pancake</a>」タグ使用<br>
 <div id=commands>
 	使用可能コマンド<br>
 	PC CLEAR cn (cn: 00-0f) / pancake.clear(cn)<br>


### PR DESCRIPTION
現在パソコンで参照した時に表示が崩れています。 `<br>` を 2 ヶ所追加しました。

![スクリーンショット 2021-04-10 14 57 23](https://user-images.githubusercontent.com/5434159/114260348-389e0880-9a0f-11eb-8c46-8ae141799143.jpg)
