### PR TITLE
SPRITE START 10～1F の背景が白固定になる

### DIFF
--- a/pancake.mjs
+++ b/pancake.mjs
@@ -608,7 +608,7 @@ class NSPanCake extends HTMLElement {
 				if (this.spritebg < 0x10) {
 					this.drawImage(this.spritebg);
 				} else {
-					this.clearDots(this.spritebg >> 4);
+					this.clearDots(this.spritebg & 0x0f);
 				}
 				for (let i = 0; i < MAX_SPRITE; i++) {
 					const sp = this.sprite[i];


### PR DESCRIPTION
上位ビットを `>> 4` なので `10` ～ `1F` は `1` → 白 が固定で使われてしまいます。

https://fukuno.jig.jp/app/IchigoJam/pancake.html#10%20%3F%22PC%20SPRITE%20START%201B%0A%0ARUN%0A

わかりやすく `& 0x0f`  としましたが、`& 15` で良かったでしょうか？
